### PR TITLE
URI encode mongo auth

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -7,15 +7,21 @@ app.delete("/api/test/:id", deleteMessage);
 var connectionString = 'mongodb://127.0.0.1:27017/test';
 
 if(process.env.MLAB_USERNAME) {
-    connectionString = process.env.MLAB_USERNAME + ":" +
-        process.env.MLAB_PASSWORD + "@" +
+    connectionString = encodeURIComponent(process.env.MLAB_USERNAME) + ":" +
+        encodeURIComponent(process.env.MLAB_PASSWORD) + "@" +
         process.env.MLAB_HOST + ':' +
         process.env.MLAB_PORT + '/' +
         process.env.MLAB_APP_NAME;
 }
 
 var mongoose = require("mongoose");
-mongoose.connect(connectionString);
+// https://stackoverflow.com/a/23344660
+mongoose.connect(connectionString, {
+    uri_decode_auth: true
+    }, function(err, db) {
+
+    }
+);
 
 var TestSchema = mongoose.Schema({
     message: String


### PR DESCRIPTION
With the template code, the mLab username and password are concatenated directly into the connection string. If they contain any characters that need to be URI encoded, this will result in a bad URI and an authentication error. This change URI encodes/decodes the username and password to fix the issue.